### PR TITLE
Move year abbreviation apostrophe

### DIFF
--- a/test/smart.test
+++ b/test/smart.test
@@ -35,9 +35,9 @@ with a close quote will be treated as an
 apostrophe:
 
 ```
-Were you alive in the 70's?
+Were you alive in the '70s?
 .
-<p>Were you alive in the 70&rsquo;s?</p>
+<p>Were you alive in the &rsquo;70s?</p>
 ```
 
 ```


### PR DESCRIPTION
As the 70 is short for 1970, the apostrophe indicates the part that is being hacked off or omitted. This is a common mistake. In this case it should be ’70s, not the possessive 70’s. Given that the apostrophe is at the beginning of the ‘word’, it’s probably a better test case too tbh.

---

Please consider moving your project to an open source or open core Git forge platform or post email address/mailing list to submit patches to. I would love to delete my GitHub account and not share data with Microsoft, but I can't make contributions to great FOSS projects like this one without an account for this proprietary service.