### PR TITLE
Fix inverted explanation of tight lists

### DIFF
--- a/doc/syntax.html
+++ b/doc/syntax.html
@@ -1243,9 +1243,9 @@ six
 </code></pre>
 </div>
 </div>
-<p>A list is classed as <em>tight</em> if it contains blank lines between items,
-or between blocks inside an item. Blank lines at the start or end of a
-list do not count against tightness.</p>
+<p>A list is classed as <em>tight</em> if it does not contain blank lines between
+items, or between blocks inside an item. Blank lines at the start or end
+of a list do not count against tightness.</p>
 <div class="example">
 <div class="djot">
 <pre><code>- one

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -504,9 +504,9 @@ its first item. The numbers of subsequent items are irrelevant.
     5) five
     8) six
 
-A list is classed as *tight* if it contains blank lines between items,
-or between blocks inside an item. Blank lines at the start or end of a
-list do not count against tightness.
+A list is classed as *tight* if it does not contain blank lines between
+items, or between blocks inside an item. Blank lines at the start or end
+of a list do not count against tightness.
 
     - one
     - two


### PR DESCRIPTION
At present, the syntax reference documents tight lists as _containing_ blank lines, which is the opposite of the example (and what one would expect of "tight" lists).

This change would reword the explanation to say that tight lists do not have blank lines between items or blocks inside an item.