### PR TITLE
Document how to run djot without installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ parser:render_html(io.stdout)
 
 The code for djot (excluding the test suite) is standard Lua,
 compatible with lua 5.1--5.4 and with luajit. It has no external
-dependencies.
+dependencies. You can run it with `lua ./bin/main.lua`.
 
 `make install` will build the rockspec and install the
 library and executable using luarocks. Once installed,


### PR DESCRIPTION
`make install` wants to write to `/` which isn't possible without `sudo` (and, on something like NixOS, isn't possible at all). Luckily, `luarocks` supports `--local` flag for installing into `~/.luarocks`. Add a make target for that.

Note that I am not really comfortable with neither make nor lua, but that's the magic spell which worked for me on NixOS!