### PR TITLE
Vim syntax

### DIFF
--- a/editors/vim/syntax/djot.vim
+++ b/editors/vim/syntax/djot.vim
@@ -22,7 +22,7 @@ syn region strong matchgroup=delimiter start='\*[^\s}]\@=\|{\*' end='[^\s{]\@=\*
 syn region superscript matchgroup=delimiter start='\^[^\s}]\@=\|{\^' end='\^}\|[^\s{]\@=\^\|^\s*$' contains=@inline
 syn region subscript matchgroup=delimiter start='\~[^\s}]\@=\|{\~' end='\~}\|[^\s{]\@=\~\|^\s*$' contains=@inline
 
-syn region highlight matchgroup=delimiter start='{=' end='=}$\|^\s*$' contains=@inline
+syn region highlight matchgroup=delimiter start='{=' end='=}\|^\s*$' contains=@inline
 syn match rawattribute "`\@<={=[A-Za-z0-9]*}"
 
 syn region insert matchgroup=delimiter start='{+' end='+}\|^\s*$' contains=@inline

--- a/editors/vim/syntax/djot.vim
+++ b/editors/vim/syntax/djot.vim
@@ -45,6 +45,8 @@ syn match emoji ':[a-zA-Z0-9_+-]\+:'
 
 syn match escape '\\[\r\n ~!@#$%^&*(){}`\[\]/=\\?+|\'",<-]'he=e-1
 
+syn region djotautolinkurl matchgroup=delimiter start=/</ end=/>/
+
 syn cluster inline contains=linkurl,emphasis,strong,codespan,attributes,rawattribute,insert,delete,superscript,subscript,highlight,math,smartquote,openbrace,closebrace,emoji,escape,footnoteref,span
 
 syn region codeblock matchgroup=delimiter start='^\s*\z(````*\)\s*=\?\w*\s*$' end='^\s*\z1`*\s*$'
@@ -66,6 +68,7 @@ hi def link string String
 hi def link inlinelink Typedef
 hi def link footnoteref Statement
 hi def link linkurl Underlined
+hi def link djotautolinkurl Underlined
 hi def link comment Comment
 hi def link linklabel Underlined
 hi def link escaped Typedef

--- a/editors/vim/syntax/djot.vim
+++ b/editors/vim/syntax/djot.vim
@@ -12,8 +12,9 @@ syn match heading '^##* .*$'
 syn region math matchgroup=delimiter skip='[^`]{1,}' start='[$][$]\?\z(``*\)' end='\z1\|^\s*$'
 syn region codespan matchgroup=delimiter skip='[^`]{1,}' start='\z(``*\)' end='\z1\|^\s*$'
 
+syn region comment matchgroup=delimiter start='%' end='%' contained
 syn region string start='"' end='"' skip='\\"'
-syn region attributes matchgroup=delimiter start="{[^\[\]_*'\"=\\+-]\@=" end="}" contains=string
+syn region attributes matchgroup=delimiter start="{[^\[\]_*'\"=\\+-]\@=" end="}" contains=string,comment
 
 syn region emphasis matchgroup=delimiter start='_[^\s}]\@=\|{_' end='_}\|[^\s{]\@=_\|^\s*$' contains=@inline
 syn region strong matchgroup=delimiter start='\*[^\s}]\@=\|{\*' end='[^\s{]\@=\*\|\*}\|^\s*$' contains=@inline
@@ -65,6 +66,7 @@ hi def link string String
 hi def link inlinelink Typedef
 hi def link footnoteref Statement
 hi def link linkurl Underlined
+hi def link comment Comment
 hi def link linklabel Underlined
 hi def link escaped Typedef
 hi def link attributes Identifier


### PR DESCRIPTION
Vim syntax for highlighted text, autolinks and comments.

Closes https://github.com/jgm/djot/issues/81