### PR TITLE
Highlight blockquote leader `>`

### DIFF
--- a/editors/vim/syntax/djot.vim
+++ b/editors/vim/syntax/djot.vim
@@ -8,6 +8,7 @@ if exists("b:current_syntax")
 endif
 
 syn match heading '^##* .*$'
+syn match blockquote '^\s*>\%(\s\|$\)'
 
 syn region math matchgroup=delimiter skip='[^`]{1,}' start='[$][$]\?\z(``*\)' end='\z1\|^\s*$'
 syn region codespan matchgroup=delimiter skip='[^`]{1,}' start='\z(``*\)' end='\z1\|^\s*$'
@@ -78,6 +79,7 @@ hi def link delimiter Ignore
 hi def link escape Ignore
 hi def link openbrace Ignore
 hi def link closebrace Ignore
+hi def link blockquote Comment
 
 let b:current_syntax = "djot"
 


### PR DESCRIPTION
This PR adds highlighting blockquote leader `>` to Vim syntax highlighter, so that users can notice it has syntactic meaning. This is the same behavior as Vim's Markdown syntax highlighting.