### PR TITLE
Test escapes in the middle of a quoted attribute.

### DIFF
--- a/test/attributes.test
+++ b/test/attributes.test
@@ -52,9 +52,15 @@ hi\{key="abc{#hi}"
 ```
 
 ```
-hi{key="\{#hi"}
+hi{key="\"#hi"}
 .
-<p><span key="{#hi">hi</span></p>
+<p><span key="&quot;#hi">hi</span></p>
+```
+
+```
+hi{key="hi\"#hi"}
+.
+<p><span key="hi&quot;#hi">hi</span></p>
 ```
 
 Line break:


### PR DESCRIPTION
I noticed there isn't a test that checks escaping of attributes, when it isn't the first character of a string.
Though I am somewhat curious if `'\{'` is really needed anymore since https://github.com/jgm/djot/commit/a6cc50f3a2568028efdef97a0fc7b85a386226aa
