### PR TITLE
Clamp heading level to 6 when outputting HTML

### DIFF
--- a/djot/html.lua
+++ b/djot/html.lua
@@ -212,9 +212,11 @@ function Renderer:section(node)
 end
 
 function Renderer:heading(node)
-  self:render_tag("h" .. node.level , node)
+  -- Heading levels higher than 6 are invalid in HTML
+  local level = math.min(node.level, 6)
+  self:render_tag("h" .. level, node)
   self:render_children(node)
-  self.out("</h" .. node.level .. ">\n")
+  self.out("</h" .. level .. ">\n")
 end
 
 function Renderer:thematic_break(node)


### PR DESCRIPTION
Given the following input:

``` djot
####### Hello!
```

The Lua code will gladly produce:

``` html
<section id="Hello">
<h7>Hello!</h7>
</section>
```

The JavaScript code does as well. `<h8>` and so on are also possible with no maximum I can find either in code or in the standard.

Only `<h1>` through `<h6>` are valid HTML. It may be useful for Djot to support heading levels higher than 6 when it is used to construct documents that support such, though in the interest of reducing ambiguity in the spec I'd suggest that some maximum is picked and I think that 6 is a reasonable number. All that being said, all this PR does is tweak html.lua such that if a heading level higher than 6 is encountered, only an `<h6>` is outputted.

Unfortunately I will not be submitting a PR for djot.js as I do not have a setup for transpiling and testing TypeScript, but I suspect a patch for that repo will be as trivial as this one.