### PR TITLE
Fix border display of table header cells

### DIFF
--- a/web/playground/preview.html
+++ b/web/playground/preview.html
@@ -6,16 +6,20 @@
   <title>djot preview</title>
   <style>
 html {
-    line-height: 1.3;
-    font-family: serif;
-    font-size: 20px;
-    height: 100%;
+  line-height: 1.3;
+  font-family: serif;
+  font-size: 20px;
+  height: 100%;
 }
-code { font-size: 16px;
+code {
+  font-size: 16px;
 }
-table, th, td {
+table {
   border-collapse: collapse;
+}
+th, td {
   border: 1px solid #ddd;
+  padding: 0 0.3em;
 }
   </style>
   <script type="text/javascript" id="MathJax-script" async

--- a/web/playground/preview.html
+++ b/web/playground/preview.html
@@ -13,7 +13,7 @@ html {
 }
 code { font-size: 16px;
 }
-table, tr, td {
+table, th, td {
   border-collapse: collapse;
   border: 1px solid #ddd;
 }


### PR DESCRIPTION
The stylesheet had a rule that was probably a typo, since it adds a border to the entire rows (`<tr>`), which is redundant with the border added to the cells (`<td>`); and it fails to add a border to `<th>` elements. So the following table:

```
| test | foo |
|------|-----|
| bar  | baz |
```

currently looks like this:

![image](https://user-images.githubusercontent.com/478237/209790996-a2693a75-142f-4213-a49d-c9fbc0829dd5.png)

With this change, it will look like this:

![image](https://user-images.githubusercontent.com/478237/209791315-a490d3a9-7189-4be7-b0cc-1adcf4cc4245.png)

Note that I also added some cell padding.

Btw, is there a reason why these styles live in the `preview.html` file instead of the `styles.css` file?