### PR TITLE
Fix typo, preceeded -> preceded

### DIFF
--- a/doc/syntax.html
+++ b/doc/syntax.html
@@ -945,7 +945,7 @@ the heading level. The following text is parsed as inline content.</p>
 </div>
 </div>
 <p>The heading text may spill over onto following lines, which may
-also be preceeded by the same number of <code>#</code> characters (but
+also be preceded by the same number of <code>#</code> characters (but
 these can also be left off).</p>
 <p>The heading ends when a blank line (or the end of the document
 or enclosing container) is encountered.</p>

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -386,7 +386,7 @@ the heading level.  The following text is parsed as inline content.
 ```
 
 The heading text may spill over onto following lines, which may
-also be preceeded by the same number of `#` characters (but
+also be preceded by the same number of `#` characters (but
 these can also be left off).
 
 The heading ends when a blank line (or the end of the document


### PR DESCRIPTION
Found via `typos --format brief`