### PR TITLE
Match reference with example

### DIFF
--- a/doc/syntax.html
+++ b/doc/syntax.html
@@ -1758,7 +1758,7 @@ adding a numerical suffix.</p>
 <p>However, for the most part you do not need to know the
 identifiers that are assigned to headings, because
 implicit link references are created for all headings.
-Thus, to link to a heading titled “Introduction” in the same
+Thus, to link to a heading titled “Epilogue” in the same
 document, one can simply use a reference link:</p>
 <div class="example">
 <div class="djot">


### PR DESCRIPTION
The old text uses an example with heading "Introduction", but the code sample shows a heading "Epilogue".