### PR TITLE
Proposal for syntax for attributes on list items

### DIFF
--- a/doc/syntax.html
+++ b/doc/syntax.html
@@ -901,6 +901,45 @@ combined. Thus,</p>
 </code></pre>
 </div>
 </div>
+<p>To attach attributes to a list item, the curly braces must immediately
+follow the list marker:</p>
+<div class="example">
+<div class="djot">
+<pre><code>+{.blue} A blue list item.
+(a){.bar} Ordered list item with an attribute.</code></pre>
+</div>
+<div class="html">
+<pre><code>&lt;ul&gt;
+&lt;li class=&quot;blue&quot;&gt;
+A blue list item.
+&lt;/li&gt;
+&lt;/ul&gt;
+&lt;ol type=&quot;a&quot;&gt;
+&lt;li class=&quot;bar&quot;&gt;
+Ordered list item with an attribute.
+&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre>
+</div>
+</div>
+<p>Conversely, in the following, the attributes are attached to the block
+quote:</p>
+<div class="example">
+<div class="djot">
+<pre><code>+ {.blue}
+  &gt; A blue quote.</code></pre>
+</div>
+<div class="html">
+<pre><code>&lt;ul&gt;
+&lt;li&gt;
+&lt;blockquote class=&quot;blue&quot;&gt;
+A blue quote.
+&lt;/blockquote&gt;
+&lt;/li&gt;
+&lt;/ul&gt;
+</code></pre>
+</div>
+</div>
 </section>
 </section>
 <section id="block-syntax" class="level2">

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -346,6 +346,18 @@ is the same as
 
     avant{lang=fr .blue}
 
+To attach attributes to a list item, the curly braces must immediately
+follow the list marker:
+
+    +{.blue} A blue list item.
+    (a){.bar} Ordered list item with an attribute.
+
+Conversely, in the following, the attributes are attached to the block
+quote:
+
+    + {.blue}
+      > A blue quote.
+
 ## Block syntax
 
 As in commonmark, block structure can be discerned prior to inline


### PR DESCRIPTION
As previously discussed in #185 

I'm not sure what the process is for a syntax change, so I'm just starting it by adding a description to `syntax.md`.

If you do like this syntax, I'm guessing I would

- send a PR to https://github.com/jgm/djot.js and https://github.com/jgm/djot.lua
  - including tests, to see if there is any parsing ambiguity
- re-generate `syntax.html` from `syntax.md` with djot.lua

Rendered docs:

![image](https://github.com/jgm/djot/assets/7741417/a63178b5-0757-4106-aa37-e52be4a930f5)
