### PR TITLE
feat(readme): add tooling section to highlight djot tools for code editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,12 @@ current development is focused on djot.js, and it is possible
 that djot.lua will not be kept up to date with the latest syntax
 changes.
 
+## Tooling
+
+- [Vim tooling (Located in this repo)](./editors/vim/)
+- [djot-vscode (Visual Studio Code keybinds, syntax markup, and export options)](https://github.com/ryanabx/djot-vscode)
+- [Djot-Marker (Visual Studio Code keybinds and syntax markup)](https://github.com/wisim3000/Djot-Marker)
+
 ## File extension
 
 The extension `.dj` may be used to indicate that the contents


### PR DESCRIPTION
I propose we add a section to highlight tooling for djot from various editors. I've included the ones I know about, which are the vim tooling from this repo, and two visual studio code extensions (one of them my own, the other being an older extension I was using before making my own)