### PR TITLE
Fix whitespace in negative charclasses

### DIFF
--- a/editors/vim/syntax/djot.vim
+++ b/editors/vim/syntax/djot.vim
@@ -17,11 +17,11 @@ syn region comment matchgroup=delimiter start='%' end='%' contained
 syn region string start='"' end='"' skip='\\"'
 syn region attributes matchgroup=delimiter start="{[^\[\]_*'\"=\\+-]\@=" end="}" contains=string,comment
 
-syn region emphasis matchgroup=delimiter start='_[^\s}]\@=\|{_' end='_}\|[^\s{]\@=_\|^\s*$' contains=@inline
-syn region strong matchgroup=delimiter start='\*[^\s}]\@=\|{\*' end='[^\s{]\@=\*\|\*}\|^\s*$' contains=@inline
+syn region emphasis matchgroup=delimiter start='_[^[:blank:]}]\@=\|{_' end='_}\|[^[:blank:]{]\@=_\|^\s*$' contains=@inline
+syn region strong matchgroup=delimiter start='\*[^[:blank:]}]\@=\|{\*' end='[^[:blank:]{]\@=\*\|\*}\|^\s*$' contains=@inline
 
-syn region superscript matchgroup=delimiter start='\^[^\s}]\@=\|{\^' end='\^}\|[^\s{]\@=\^\|^\s*$' contains=@inline
-syn region subscript matchgroup=delimiter start='\~[^\s}]\@=\|{\~' end='\~}\|[^\s{]\@=\~\|^\s*$' contains=@inline
+syn region superscript matchgroup=delimiter start='\^[^[:blank:]}]\@=\|{\^' end='\^}\|[^[:blank:]{]\@=\^\|^\s*$' contains=@inline
+syn region subscript matchgroup=delimiter start='\~[^[:blank:]}]\@=\|{\~' end='\~}\|[^[:blank:]{]\@=\~\|^\s*$' contains=@inline
 
 syn region highlight matchgroup=delimiter start='{=' end='=}\|^\s*$' contains=@inline
 syn match rawattribute "`\@<={=[A-Za-z0-9]*}"


### PR DESCRIPTION
In vim patterns, `\s` inside a "collection" matches literal s, not space-or-tab. Buried in `:help collection` is this factoid:

    NOTE: The other backslash codes mentioned above do not work inside
    []!

So before this fix, `_something_` wouldn't start an emphasis at the first underscore because the pattern for the syntax region required underscore not-followed-by `s`. This diff replaces `\s` inside square bracket patterns with `[:blank:]`, which is a character class expression for "space or tab".
