### PR TITLE
docs: add helix support to tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,14 +333,14 @@ changes.
 
 ## Tooling
 
-- [Vim tooling](./editors/vim/) (located in this repo)
-- Visual Studio Code tooling
+- [Vim](./editors/vim/) tooling is in this repository
+- [Emacs](./editors/emacs/) tooling is in this repository and requires the tree-sitter grammar
+- [Helix](https://github.com/helix-editor/helix) has built-in syntax highlighting
+- Visual Studio Code
   - [djot-vscode](https://github.com/ryanabx/djot-vscode)
   - [Djot-Marker](https://github.com/wisim3000/Djot-Marker)
 - [Treesitter grammar](https://github.com/treeman/tree-sitter-djot)
-- [Emacs major mode](./editors/emacs/)
-  (located in this repo, requires the treesitter grammar)
-- [Djockey](https://steveasleep.com/djockey/), a static site generator
+- [Djockey](https://steveasleep.com/djockey/) is a static site generator
   for technical writing and project documentation.
 
 ## File extension


### PR DESCRIPTION
helix-editor/helix#12562 was merged recently, adding syntax highlighting for djot to the Helix editor. From (presumably) the next release of Helix, all users will have support for djot by default.

I'd like to mention this in the tooling section of the README. (I've also made a minor formatting change to make the section a bit more homogenous in structure).