### PR TITLE
Add djot-php (PHP) implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,11 +315,12 @@ A vim syntax highlighting definition for djot is provided in
 
 ## Implementations
 
-There are currently six djot implementations:
+There are currently seven djot implementations:
 
 - [djot.js (JavaScript/TypeScript)](https://github.com/jgm/djot.js)
 - [djot.lua (Lua)](https://github.com/jgm/djot.lua)
 - [djota (Prolog)](https://github.com/aarroyoc/djota)
+- [djot-php (PHP)](https://github.com/php-collective/djot-php)
 - [jotdown (Rust)](https://github.com/hellux/jotdown)
 - [godjot (Go)](https://github.com/sivukhin/godjot)
 - [djoths (Haskell)](https://github.com/jgm/djoths)


### PR DESCRIPTION
Add PHP implementation to the list of djot implementations.

**Repository:** https://github.com/php-collective/djot-php

**Features:**
- Full Djot syntax support (block and inline elements)
- Multiple renderers: HTML, PlainText, Markdown
- Event system for render customization
- Custom inline/block pattern registration for extensibility

Live sandbox included