### PR TITLE
Update README to include WordPress plugin for djot-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ There are currently seven djot implementations:
 - [djot.js (JavaScript/TypeScript)](https://github.com/jgm/djot.js)
 - [djot.lua (Lua)](https://github.com/jgm/djot.lua)
 - [djota (Prolog)](https://github.com/aarroyoc/djota)
-- [djot-php (PHP)](https://github.com/php-collective/djot-php)
+- [djot-php (PHP)](https://github.com/php-collective/djot-php) along with a [wordpress plugin](https://github.com/php-collective/wp-djot)
 - [jotdown (Rust)](https://github.com/hellux/jotdown)
 - [godjot (Go)](https://github.com/sivukhin/godjot)
 - [djoths (Haskell)](https://github.com/jgm/djoths)


### PR DESCRIPTION
Added a note about the WordPress plugin for djot-php:
https://github.com/php-collective/wp-djot