### PR TITLE
Update README to specify .djot extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ changes.
 
 ## File extension
 
-The extension `.dj` may be used to indicate that the contents
-of a file are djot-formatted text.
+The extension `.djot` or `.dj` may be used to indicate that the contents
+of a file are djot-formatted text. Consider that `.djot` may be more speaking to the format.
 
 ## License
 


### PR DESCRIPTION
Clarify file extension for djot-formatted text.

Personally I would prefer the speaking form to help people understand the format if they encounter a file.
Googling for .dj might not yield results.

//EDIT:
Its actually worse, if you google it, you find things like https://www.filesuffix.com/en/extension/dj
