### PR TITLE
Clarify symbol boundary rules for digits

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -298,6 +298,12 @@ emojis. But this is not built into djot.)
 
     My reaction is :+1: :smiley:.
 
+A colon that is directly adjacent to a digit on both sides does not
+open or close a symbol.  This prevents time formats and other
+numeric notations from being misinterpreted:
+
+    The meeting is at 10:30:00.
+
 ### Raw inline
 
 Raw inline content in any format may be included using a verbatim span


### PR DESCRIPTION
## Summary

- Adds spec text clarifying that colons directly adjacent to digits on both sides do not open or close symbol syntax
- This prevents time formats like `10:30:00` from being misinterpreted as containing symbols (e.g., `:30:`)

Partially addresses #350.

A reference implementation already exists in [djot-php](https://github.com/php-collective/djot-php/blob/master/docs/enhancements.md#symbol-parsing-in-time-formats), closing the gap between upstream spec and downstream implementations.