### PR TITLE
Clarify em/en dash behavior with unmatched delete opener

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -244,6 +244,13 @@ en-dashes, while 6 hyphens become two em-dashes).
 
     a----b c------d
 
+An unmatched `{-` (a delete opener without a corresponding closer)
+should not prevent em-dash or en-dash conversion of subsequent hyphens.
+The `{` is treated as literal text when no matching `-}` is found:
+
+    {--- produces a literal `{` followed by an em-dash.
+    {-- produces a literal `{` followed by an en-dash.
+
 ### Math
 
 To include LaTeX math, put the math in a verbatim span and prefix it


### PR DESCRIPTION
## Summary

- Adds spec text clarifying that an unmatched `{-` (delete opener without a corresponding `-}` closer) should not prevent em-dash or en-dash conversion of subsequent hyphens
- `{---` should produce a literal `{` followed by an em-dash, and `{--` should produce a literal `{` followed by an en-dash

Addresses #125.

A reference implementation already exists in [djot-php](https://github.com/php-collective/djot-php/blob/master/docs/enhancements.md#emen-dash-with-unmatched-braces), closing the gap between upstream spec and downstream implementations.