### PR TITLE
Add boolean/flag attribute shorthand to attribute syntax

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -331,6 +331,10 @@ Inside the curly braces, the following syntax is possible:
   are not needed when the value consists entirely of ASCII alphanumeric
   characters or `_` or `:` or `-`. Backslash escapes may be used inside
   quoted values.
+- A bare `key` (a word consisting of ASCII alphanumeric characters,
+  `_`, or `-`, not followed by `=`) specifies a boolean attribute. This
+  is equivalent to `key=""` and maps to HTML boolean attributes such as
+  `disabled`, `hidden`, `reversed`, `open`, and `download`.
 - `%` begins a comment, which ends with the next `%` or the end of the
   attribute (`}`).
 
@@ -349,6 +353,15 @@ combined. Thus,
 is the same as
 
     avant{lang=fr .blue}
+
+Boolean attributes can be combined freely with other attribute types:
+
+    [Download](file.zip){download .btn}
+
+    {reversed}
+    1. Third
+    2. Second
+    3. First
 
 ## Block syntax
 


### PR DESCRIPTION
## Summary

- Adds boolean/flag attribute shorthand to the attribute syntax specification
- A bare `key` (not followed by `=`) specifies a boolean attribute, equivalent to `key=""`
- Common HTML boolean attributes (`disabled`, `hidden`, `reversed`, `open`, `download`) can be written without the awkward `{reversed="reversed"}` workaround
- Boolean attributes can be combined freely with classes, IDs, and key-value attributes

Examples:

```djot
[Download](file.zip){download .btn}

{reversed}
1. Third
2. Second
3. First
```

Addresses #257.

A reference implementation already exists in [djot-php](https://github.com/php-collective/djot-php/blob/master/docs/enhancements.md#boolean-attribute-shorthand), closing the gap between upstream spec and downstream implementations.