### PR TITLE
Extend caption syntax to images and block quotes

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -673,14 +673,42 @@ verbatim spans; these do not count as cell separators:
 
     | just two \| `|` | cells in this table |
 
-You can attach a caption to a table using the following syntax:
+Tables support captions; see [Caption] below.
 
-    ^ This is the caption.  It can contain _inline formatting_
-      and can extend over multiple lines, provided they are
-      indented relative to the `^`.
+### Caption
 
-The caption can come directly after the table, or there can
-be an intervening blank line.
+A caption can be attached to a table, an image, or a block quote by
+placing a line starting with `^` followed by a space after the element.
+The caption can come directly after the element, or there can be an
+intervening blank line. The caption text is parsed as inline content
+and can extend over multiple lines, provided they are indented relative
+to the `^`.
+
+A table caption produces a `<caption>` element inside the table:
+
+    | fruit  | price |
+    |--------|------:|
+    | apple  |     4 |
+    ^ Fruit prices in the market
+
+When a paragraph contains only an image and is followed by a caption,
+the image and caption are wrapped in a `<figure>` element with a
+`<figcaption>`:
+
+    ![Sunset over the ocean](sunset.jpg)
+    ^ A beautiful sunset captured at the beach
+
+A block quote followed by a caption is wrapped in a `<figure>` element
+with a `<figcaption>`, which is useful for attributions:
+
+    > To be or not to be, that is the question.
+    ^ William Shakespeare, Hamlet
+
+Multi-line captions are supported:
+
+    ![Historic photo](apollo.jpg)
+    ^ This photograph was taken in 1969
+      during the Apollo 11 mission.
 
 ### Reference link definition
 

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -677,29 +677,34 @@ Tables support captions; see [Caption] below.
 
 ### Caption
 
-A caption can be attached to a table, an image, or a block quote by
-placing a line starting with `^` followed by a space after the element.
-The caption can come directly after the element, or there can be an
+A caption provides a title or description for an element. A caption
+can be attached to a table, an image, or a block quote by placing a
+line starting with `^` followed by a space after the element. The
+caption can come directly after the element, or there can be an
 intervening blank line. The caption text is parsed as inline content
 and can extend over multiple lines, provided they are indented relative
 to the `^`.
 
-A table caption produces a `<caption>` element inside the table:
+For tables, the caption is associated with the table itself:
 
     | fruit  | price |
     |--------|------:|
     | apple  |     4 |
     ^ Fruit prices in the market
 
+When rendered to HTML, this produces a `<caption>` element inside
+the `<table>`.
+
 When a paragraph contains only an image and is followed by a caption,
-the image and caption are wrapped in a `<figure>` element with a
-`<figcaption>`:
+the image becomes a figure - a self-contained unit with its caption:
 
     ![Sunset over the ocean](sunset.jpg)
     ^ A beautiful sunset captured at the beach
 
-A block quote followed by a caption is wrapped in a `<figure>` element
-with a `<figcaption>`, which is useful for attributions:
+When rendered to HTML, this uses `<figure>` and `<figcaption>` elements.
+
+A block quote followed by a caption also becomes a figure, which is
+useful for attributions:
 
     > To be or not to be, that is the question.
     ^ William Shakespeare, Hamlet


### PR DESCRIPTION
## Summary

- Extends the existing `^ caption` syntax (currently tables only) to also support images and block quotes
- Extracts caption rules into a dedicated "Caption" section in the spec for clarity
- Image + caption: wraps in `<figure>` with `<figcaption>`
- Block quote + caption: wraps in `<figure>` with `<figcaption>`, useful for attributions
- Table caption behavior is unchanged (`<caption>` element)
- Multi-line caption example included

This is a natural extension of the table caption syntax that already exists in the spec, using the same `^ ` marker consistently across elements.

Examples:

```djot
![Sunset over the ocean](sunset.jpg)
^ A beautiful sunset captured at the beach

> To be or not to be, that is the question.
^ William Shakespeare, Hamlet
```

Addresses #28 and #31.

A reference implementation already exists in djot-php:
- https://php-collective.github.io/djot-php/guide/syntax.html#block-quote-captions
- https://php-collective.github.io/djot-php/guide/syntax.html#image-captions

closing the gap between upstream spec and downstream implementations.