### PR TITLE
Add fenced comment block syntax (%%%)

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -648,6 +648,18 @@ use a longer opening fence:
     This %%% is not the end.
     %%%%
 
+Note that fenced comment blocks are block-level elements and will
+break paragraph continuity:
+
+    Lorem ipsum
+    %%%
+    comment
+    %%%
+    dolor sit amet
+
+This produces two separate paragraphs, not one. For comments that
+should not interrupt paragraph flow, use inline comments (`{% ... %}`).
+
 ### Pipe table
 
 A pipe table consists of a sequence of *rows*. Each row starts and ends

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -289,6 +289,10 @@ attribute specifier that contains only a comment:
     Foo bar {% This is a comment, spanning
     multiple lines %} baz.
 
+Note that inline comments cannot contain blank lines (since blank
+lines act as paragraph separators). For multi-line comments that
+may contain blank lines, use a [fenced comment block].
+
 ### Symbols
 
 Surrounding a word with `:` signs creates a "symbol," which by
@@ -612,6 +616,37 @@ The contents of a div are interpreted as block-level content.
 
     And here is another.
     :::
+
+### Fenced comment block
+
+A fenced comment block begins with a line of three or more consecutive
+percent signs (`%`), and ends with a line of consecutive percent signs
+at least as long as the opening fence, or with the end of the document
+or containing block.
+
+The contents of a fenced comment block are ignored entirely; they do
+not appear in the rendered output.
+
+    %%%
+    This is a comment block.
+    It can span multiple lines.
+    %%%
+
+Unlike inline comments (`{% ... %}`), fenced comment blocks can contain
+blank lines:
+
+    %%%
+    First paragraph of comment.
+
+    Second paragraph of comment.
+    %%%
+
+To include a run of three or more percent signs inside a comment,
+use a longer opening fence:
+
+    %%%%
+    This %%% is not the end.
+    %%%%
 
 ### Pipe table
 


### PR DESCRIPTION
## Summary

- Adds block-level fenced comment syntax using `%%%` delimiters
- Unlike inline comments (`{% %}`), fenced comment blocks can contain blank lines
- Closing fence must have at least as many `%` as the opening fence
- Content is ignored entirely (not rendered)
- Cross-references the inline Comment section to mention the fenced alternative

The `%` character is already the comment character in djot attributes, making `%%%` a natural choice that follows the existing fenced pattern (`` ``` `` for code, `:::` for divs).

```djot
%%%
This comment can contain

blank lines and multiple paragraphs.
%%%
```

Addresses #67.

A reference implementation exists in [djot-php](https://github.com/php-collective/djot-php/blob/master/docs/enhancements.md#fenced-comment-blocks).