### PR TITLE
Clarify: emphasis delimiters inside link destinations are literal

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -32,6 +32,15 @@ contains a link, while
 
 does not (because the strong emphasis closes over the `[` delimiter).
 
+Note that inline formatting delimiters inside link destinations are
+treated as literal text and do not interfere with emphasis matching.
+Thus,
+
+    _[link](http://example.com?foo_bar=1), more text_
+
+produces emphasis around the link and trailing text, because the `_`
+inside the URL does not close the outer emphasis.
+
 Although overlapping containers are ruled out, *nested* containers are
 fine:
 

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -32,14 +32,10 @@ contains a link, while
 
 does not (because the strong emphasis closes over the `[` delimiter).
 
-Note that inline formatting delimiters inside link destinations are
-treated as literal text and do not interfere with emphasis matching.
-Thus,
-
-    _[link](http://example.com?foo_bar=1), more text_
-
-produces emphasis around the link and trailing text, because the `_`
-inside the URL does not close the outer emphasis.
+Note that code spans and link destinations are resolved before emphasis
+is matched, so delimiters inside them (such as the `_` in
+`[link](http://example.com?foo_bar=1)`) are not available to open or
+close emphasis.
 
 Although overlapping containers are ruled out, *nested* containers are
 fine:


### PR DESCRIPTION
Related: https://github.com/jgm/djot/issues/375
JS implementation fix: https://github.com/jgm/djot.js/pull/125
PHP implementation fix: https://github.com/php-collective/djot-php/pull/81

## Summary

Adds a clarifying note to the Precedence section of the syntax spec explaining that inline formatting delimiters inside link destinations are treated as literal text.

This covers the **destination-only** case:

- `_` or `*` inside a URL like `(http://example.com?foo_bar=1)` does not participate in emphasis matching

The bracket-text case (`_[bar_](url)`) is intentionally **not** changed - emphasis continues to take precedence per the existing "first to start wins" rule.

Per discussion in #375, this is the simpler fix that addresses the main real-world issue (URLs with underscores in query params) without the complexity of lookahead parsing.