### PR TITLE
List zjot (Zig) implementation.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -193,7 +193,8 @@ The project began as an attempt to implement some of the ideas I suggested in <a
     <a href="https://github.com/aarroyoc/djota">Prolog</a>,
     <a href="https://github.com/hellux/jotdown">Rust</a>,
     <a href="https://github.com/sivukhin/godjot">Go</a>,
-    <a href="https://github.com/php-collective/djot-php">PHP</a>.
+    <a href="https://github.com/php-collective/djot-php">PHP</a>,
+    <a href="https://github.com/QuiteClose/zjot">Zig</a>.
   </li>
 </ul>
 


### PR DESCRIPTION
I'm building a static-site generator in Zig and I require fine-grained control over which classes are applied in the HTML output:

* Markdown gives insufficient control.
* Djot is perfect for what I need.
* [zjot](https://github.com/QuiteClose/zjot) is a fully compliant Zig implementation.

All tests from the dot.js repo pass but it's hard to find large djot documents to benchmark/verify against. I ended up using pandoc to convert the [Pro Git Book](https://github.com/progit/progit) to djot and then rendering the document using different djot implementations. Here, zjot gives byte-identical output with dot.js and the jotdown (the Rust implementation.) The djot.lua implementation outputs HTML entities instead of e.g. quotes, but otherwise the content is identical there too.

Thank you for inventing djot, it will make a significant improvement to the site-generator that I am planning.