### PR TITLE
Add line comment syntax (`%%` to end of line)

### DIFF
--- a/doc/cheatsheet.md
+++ b/doc/cheatsheet.md
@@ -23,8 +23,10 @@ Leave a blank line between paragraphs.
 > content in here.
 ~~~
 
-**Comments** `{% look like this`\
-`and can span multiple lines %}`.
+**Line comments** start with `%%` and extend to end of line:\
+`visible text %% this is a comment`
+
+**Attribute comments** `{% look like this %}`.
 
 **Thematic break** (horizontal line): `***` or `---` on its own line.
 Can be longer than three characters, and may contain or be indented

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -278,16 +278,38 @@ backslash + newline:
 
 ### Comment
 
+Djot supports two styles of comments: line comments and attribute comments.
+
+#### Line comments
+
+A line comment begins with `%%` and extends to the end of the line.
+Everything from `%%` to the end of the line is ignored.
+
+    This is visible %% but this is a comment
+    %% This entire line is a comment
+    More visible text
+
+Line comments work in both inline and block contexts. To comment out
+multiple lines, mark each line with `%%`:
+
+    %% These lines are
+    %% commented out
+    This line is not
+
+Line comments make it visually obvious which parts are commented out,
+even without syntax highlighting.
+
+#### Attribute comments
+
 Material between two `%` characters in an attribute will be ignored and
 treated as a comment. This allows comments to be added to attributes:
 
     {#ident % later we'll add a class %}
 
-But it also serves as a general way to add comments. Just use an
+Attribute comments can also be used as inline comments by using an
 attribute specifier that contains only a comment:
 
-    Foo bar {% This is a comment, spanning
-    multiple lines %} baz.
+    Foo bar {% inline comment %} baz.
 
 ### Symbols
 


### PR DESCRIPTION
## Summary

Introduces a dedicated line comment syntax: `%%` extends to the end of the line and is ignored.

```djot
This is visible %% but this is a comment
%% This entire line is a comment
More visible text
```

To comment out multiple lines, mark each line:

```djot
%% These lines are
%% commented out
This line is not
```

## Motivation

Addresses the limitations of attribute-based comments discussed in #67:

- Visually obvious what's commented out, even without syntax highlighting
- Works uniformly in inline and block contexts  
- No issues with blank lines breaking multi-line comments
- Easy for editors to toggle (like Ctrl+/ in most IDEs)
- Follows established pattern from LaTeX

The existing attribute comment syntax (`{% ... %}`) is preserved for adding comments within attributes.

## Changes

- `doc/syntax.md`: Added "Line comments" subsection under Comment, reorganized existing attribute comment docs
- `doc/cheatsheet.md`: Updated comment examples to show both styles

Refs #67