### PR TITLE
Add abbreviation definition syntax

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -717,6 +717,35 @@ definition.
 
 Here we get a link with title “bar”.
 
+### Abbreviation definition
+
+An abbreviation definition consists of `*[`, followed by the abbreviation
+text, followed by `]:`, followed by whitespace and the expansion text.
+The expansion text may span multiple lines if subsequent lines are
+indented.
+
+    *[HTML]: Hyper Text Markup Language
+
+    *[W3C]: World Wide Web Consortium
+
+When the parser encounters the defined abbreviation as a complete word
+in inline content, it wraps it in an abbreviation element (in HTML,
+`<abbr>` with a `title` attribute containing the expansion).
+
+    The HTML specification is maintained by the W3C.
+
+    *[HTML]: Hyper Text Markup Language
+    *[W3C]: World Wide Web Consortium
+
+The abbreviation definitions themselves are not rendered in the output.
+
+Matching is case-sensitive and respects word boundaries: defining `HTML`
+will not match `XHTML` or `html`. Only complete word matches are
+replaced.
+
+Abbreviation definitions may appear anywhere in the document; their
+position does not affect which text gets wrapped.
+
 ### Footnote
 
 A footnote consists of a footnote reference followed by a colon followed


### PR DESCRIPTION
This PR adds abbreviation definition syntax to djot, enabling automatic wrapping of defined terms in abbreviation elements throughout a document.

## Syntax

```djot
*[HTML]: Hyper Text Markup Language
*[W3C]: World Wide Web Consortium
```

When these abbreviations appear in text, they render as:

```html
<abbr title="Hyper Text Markup Language">HTML</abbr>
<abbr title="World Wide Web Consortium">W3C</abbr>
```

## Rationale

### 1. Accessibility

Screen readers can expand abbreviations for users, improving comprehension. The `<abbr>` element with a `title` attribute is the semantic HTML way to provide this.

### 2. DRY Principle

Currently, the only way to create abbreviations in djot is manually per occurrence:

```djot
[HTML]{title="Hyper Text Markup Language"}
```

For technical documentation with dozens of acronyms appearing multiple times, this is tedious and error-prone. Define-once, apply-everywhere is more practical.

### 3. Established Syntax

The `*[ABBR]: expansion` syntax is well-established:

- **PHP Markdown Extra** (2006) - original implementation
- **Pandoc** - supports via `abbreviations` extension
- **Python-Markdown** - `abbr` extension
- **Maruku**, **kramdown**, **Marked** - all support this syntax
- **djot-php** - already implements this

This isn't inventing new syntax—it's adopting a proven pattern.

### 4. Fits Djot's Design

The syntax mirrors existing djot patterns:

| Feature | Syntax |
|---------|--------|
| Reference link | `[label]: url` |
| Footnote | `[^label]: content` |
| **Abbreviation** | `*[ABBR]: expansion` |

The `*` prefix distinguishes it from links, and the structure is consistent with other definition-style blocks.

### 5. Non-Breaking Addition

- New syntax that doesn't conflict with existing constructs
- `*[` at line start isn't valid in current djot
- Documents without abbreviation definitions are unaffected

## Implementation Notes

- Definitions can appear anywhere in the document
- Matching is case-sensitive and word-boundary aware
- Multiple definitions for different cases (`HTML` vs `html`) are valid
- The definitions themselves don't render in output

## Prior Art / Requests

- [Pandoc #167](https://github.com/jgm/pandoc/issues/167) - Request from 2012, still referenced
- [Pandoc #9227](https://github.com/jgm/pandoc/issues/9227) - Recent discussion on abbreviation syntax
- PHP Markdown Extra documentation: https://michelf.ca/projects/php-markdown/extra/#abbr

## Reference Implementation

[djot-php](https://github.com/php-collective/djot-php) implements this syntax and can serve as a reference:
https://php-collective.github.io/djot-php/guide/syntax.html#abbreviations-extension
 A corresponding PR for djot.js can follow if this spec change is accepted.
