### PR TITLE
Allow underscore `[_]` for unchecked task list items

### DIFF
--- a/doc/syntax.html
+++ b/doc/syntax.html
@@ -1183,8 +1183,8 @@ list item.&lt;/p&gt;
 valid lower-alpha-enumerated marker.</p>
 <section id="task-list-item" class="level4">
 <h4>Task list item</h4>
-<p>A bullet list item that begins with <code>[ ]</code>, <code>[X]</code>, or <code>[x]</code> followed by a
-space is a task list item, either unchecked (<code>[ ]</code>) or checked (<code>[X]</code> or
+<p>A bullet list item that begins with <code>[ ]</code>, <code>[_]</code>, <code>[X]</code>, or <code>[x]</code> followed by a
+space is a task list item, either unchecked (<code>[ ]</code> or <code>[_]</code>) or checked (<code>[X]</code> or
 <code>[x]</code>).</p>
 </section>
 <section id="definition-list-item" class="level4">

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -481,8 +481,8 @@ valid lower-alpha-enumerated marker.
 
 #### Task list item
 
-A bullet list item that begins with `[ ]`, `[X]`, or `[x]` followed by a
-space is a task list item, either unchecked (`[ ]`) or checked (`[X]` or
+A bullet list item that begins with `[ ]`, `[_]`, `[X]`, or `[x]` followed by a
+space is a task list item, either unchecked (`[ ]` or `[_]`) or checked (`[X]` or
 `[x]`).
 
 #### Definition list item


### PR DESCRIPTION
## Summary

This PR adds `[_]` as an alternative marker for unchecked task list items, addressing #305.

The underscore provides a visual representation that looks like an empty box `[_]` in the source, improving readability especially in editors without monospaced fonts (e.g., mobile apps, browser text areas).

### Changes

- Updated spec in `doc/syntax.md` to accept `[_]` alongside `[ ]` for unchecked items
- Updated `doc/syntax.html` to match

### Example

```
- [_] unchecked item with underscore
- [ ] unchecked item with space
- [x] checked item
```

This change is additive and backward-compatible with existing documents.

Closes #305

---

Reference impl / demo: https://php-collective.github.io/djot-php/guide/syntax.html#task-lists