### PR TITLE
Document HTML output security considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ These goals motivated the following decisions:
 
 For a full syntax reference, see the
 [syntax description](https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html).
+If you render untrusted djot input to HTML, see the Security section
+there; HTML output is not necessarily sanitized and should be sanitized
+downstream before being served in a browser.
 
 A vim syntax highlighting definition for djot is provided in
 `editors/vim/`.
@@ -358,4 +361,3 @@ There is no official MIME type, but `text/x-djot` may be used.
 ## License
 
 The code and documentation are released under the MIT license.
-

--- a/README.md
+++ b/README.md
@@ -309,9 +309,9 @@ These goals motivated the following decisions:
 
 For a full syntax reference, see the
 [syntax description](https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html).
-If you render untrusted djot input to HTML, see the Security section
-there; HTML output is not necessarily sanitized and should be sanitized
-downstream before being served in a browser.
+When rendering untrusted djot input to HTML, remember that HTML output is
+not necessarily sanitized; sanitize it downstream before serving it in a
+browser.
 
 A vim syntax highlighting definition for djot is provided in
 `editors/vim/`.

--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -790,6 +790,25 @@ See the [Epilogue][].
 # Epilogue
 ```
 
+## Security
+
+Djot renderers do not necessarily sanitize HTML output. If you render
+untrusted djot input to HTML, the resulting HTML can contain executable
+JavaScript or otherwise unsafe markup, and should be sanitized before it
+is served in a browser.
+
+In particular, unsafe HTML can be produced through:
+
+- raw inline or block content marked for HTML output,
+- attributes such as `onclick`, `srcdoc`, or `formaction`,
+- unsafe URL schemes in links or images, such as `javascript:` or
+  `data:`.
+
+Applications that render user-supplied djot to HTML should sanitize the
+rendered HTML with a sanitizer appropriate for their output environment.
+Sanitization is output-format-specific and is the responsibility of the
+consuming application.
+
 ## Nesting limits
 
 Conforming implementations can impose reasonable limits on


### PR DESCRIPTION
Adds a Security section to the syntax reference documenting that HTML output is not necessarily sanitized, and that consumers rendering untrusted djot to HTML should sanitize downstream.

The section names the main HTML injection surfaces called out in #403:
- raw inline/block HTML content
- attributes such as `onclick`, `srcdoc`, or `formaction`
- unsafe URL schemes such as `javascript:` or `data:`

Also adds a short README pointer to the syntax reference.

I did not regenerate `doc/syntax.html` locally because `pandoc` is not available in this environment.